### PR TITLE
Add support for 'p24_channel' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ if ($response->isSuccessful()) {
 }
 ```
 
+Optionally you can specify the payment channels allowed adding the 'channel' parameter in the Gateway
+initialization call.
+
+```
+$gateway->initialize([
+    //[...]
+    'channel' => Gateway::P24_CHANNEL_CC,
+]);
+    
+```
+
+For a list of all the supported values for 'Channel' you can read the [przelewy24 documentation](http://www.przelewy24.pl/eng/storage/app/media/pobierz/Instalacja/przelewy24_specification.pdf)
+
 ## Support
 
 If you are having general issues with Omnipay, we suggest posting on

--- a/src/Exception/NonValidChannelException.php
+++ b/src/Exception/NonValidChannelException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Omnipay\Przelewy24\Exception;
+
+class NonValidChannelException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct('The provided channel is not valid');
+    }
+}

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -3,12 +3,18 @@
 namespace Omnipay\Przelewy24;
 
 use Omnipay\Common\AbstractGateway;
+use Omnipay\Przelewy24\Exception\NonValidChannelException;
 
 /**
  * Przelewy24 Gateway
  */
 class Gateway extends AbstractGateway
 {
+    const P24_CHANNEL_CC = 1;
+    const P24_CHANNEL_BANK_TRANSFERS = 2;
+    const P24_CHANNEL_MANUAL_TRANSFER = 4;
+    const P24_CHANNEL_ALL_METHODS_24_7 = 16;
+    const P24_CHANNEL_USE_PREPAYMENT = 32;
     /**
      * Get gateway display name
      *
@@ -84,6 +90,26 @@ class Gateway extends AbstractGateway
     }
 
     /**
+     * @return string
+     */
+    public function getChannel()
+    {
+        return $this->getParameter('channel');
+    }
+
+    /**
+     * @param  int $value
+     * @return $this
+     * @throws NonValidChannelException
+     */
+    public function setChannel($value)
+    {
+        $this->validateChannelValue($value);
+
+        return $this->setParameter('channel', $value);
+    }
+
+    /**
      * @param  array $parameters
      * @return \Omnipay\Przelewy24\Message\PurchaseRequest
      */
@@ -99,5 +125,33 @@ class Gateway extends AbstractGateway
     public function completePurchase(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\Przelewy24\Message\CompletePurchaseRequest', $parameters);
+    }
+
+    /**
+     * @return array
+     */
+    private function getValidChannelValues()
+    {
+        $validChannelValues = [
+            self::P24_CHANNEL_CC,
+            self::P24_CHANNEL_BANK_TRANSFERS,
+            self::P24_CHANNEL_MANUAL_TRANSFER,
+            self::P24_CHANNEL_ALL_METHODS_24_7,
+            self::P24_CHANNEL_USE_PREPAYMENT,
+        ];
+
+        return $validChannelValues;
+    }
+
+    /**
+     * @param $value
+     *
+     * @throws NonValidChannelException
+     */
+    private function validateChannelValue($value)
+    {
+        if (!in_array($value, $this->getValidChannelValues())) {
+            throw new NonValidChannelException();
+        }
     }
 }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -64,6 +64,23 @@ abstract class AbstractRequest extends BaseAbstractRequest
     /**
      * @return string
      */
+    public function getChannel()
+    {
+        return $this->getParameter('channel');
+    }
+
+    /**
+     * @param  string $value
+     * @return $this
+     */
+    public function setChannel($value)
+    {
+        return $this->setParameter('channel', $value);
+    }
+
+    /**
+     * @return string
+     */
     public function getEndpoint()
     {
         return $this->getTestMode() ? $this->testEndpoint : $this->liveEndpoint;

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -85,6 +85,10 @@ class PurchaseRequest extends AbstractRequest
             'p24_api_version' => self::$apiVersion,
         );
 
+        if (null !== $this->getChannel()) {
+            $data['p24_channel'] = $this->getChannel();
+        }
+
         $items = $this->getItems();
         if ($items) {
             $index = 1;

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Przelewy24;
 
+use Omnipay\Przelewy24\Exception\NonValidChannelException;
 use Omnipay\Tests\GatewayTestCase;
 
 class GatewayTest extends GatewayTestCase
@@ -69,6 +70,26 @@ class GatewayTest extends GatewayTestCase
 
         $this->gateway->setCrc($crc);
         $this->assertSame($crc, $this->gateway->getCrc());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_set_and_get_channel()
+    {
+        $channel = 32;
+
+        $this->gateway->setChannel($channel);
+        $this->assertSame($channel, $this->gateway->getChannel());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_throw_exception_when_setting_an_unsupported_channel()
+    {
+        $this->setExpectedException(NonValidChannelException::class);
+        $this->gateway->setChannel(100);
     }
 
     /**

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\Przelewy24\Message;
 
 use Omnipay\Common\CreditCard;
+use Omnipay\Przelewy24\Gateway;
 use Omnipay\Tests\TestCase;
 
 class PurchaseRequestTest extends TestCase
@@ -34,7 +35,16 @@ class PurchaseRequestTest extends TestCase
         ));
     }
 
-    public function testGetData()
+    public function channelProvider() {
+        return [
+            [Gateway::P24_CHANNEL_USE_PREPAYMENT],
+            [null],
+        ];
+    }
+    /**
+     * @dataProvider channelProvider
+     */
+    public function testGetData($channel)
     {
         $card = new CreditCard(array(
             'email' => 'test@example.com',
@@ -52,6 +62,7 @@ class PurchaseRequestTest extends TestCase
             'returnUrl'   => 'https://www.example.com/return',
             'notifyUrl'   => 'https://www.example.com/notify',
             'card'        => $card,
+            'channel'     => $channel,
         ));
 
         $data = $this->request->getData();
@@ -67,7 +78,14 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('https://www.example.com/notify', $data['p24_url_status']);
         $this->assertSame('d565d579d28f4374a7c2852a8e3f8fd7', $data['p24_sign']);
         $this->assertSame('3.2', $data['p24_api_version']);
-        $this->assertCount(15, $data);
+
+        if (null === $channel) {
+            $this->assertCount(15, $data);
+        } else {
+            $this->assertSame($channel, $data['p24_channel']);
+            $this->assertCount(16, $data);
+        }
+
     }
 
     public function testSendSuccess()


### PR DESCRIPTION
This commit adds support for sending the 'p24_channel' parameter when
executing a 'PurchaseRequest' call.

This parameter allows selecting which payment options will be available
for the final user.

Documentation about the parameter can be found @
http://www.przelewy24.pl/eng/storage/app/media/pobierz/Instalacja/przelewy24_specification.pdf